### PR TITLE
Handle generated config file directories

### DIFF
--- a/src/frpcManager.js
+++ b/src/frpcManager.js
@@ -124,8 +124,23 @@ function buildToml(config) {
   return lines.join(os.EOL) + os.EOL;
 }
 
+function ensureFileTarget(filePath) {
+  try {
+    const stats = fs.lstatSync(filePath);
+    if (stats.isDirectory()) {
+      fs.rmSync(filePath, { recursive: true, force: true });
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
 function ensureConfigFiles(config) {
   fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  ensureFileTarget(GENERATED_INI);
+  ensureFileTarget(GENERATED_TOML);
   const iniBody = buildIni(config);
   const tomlBody = buildToml(config);
   fs.writeFileSync(GENERATED_INI, iniBody, 'utf-8');


### PR DESCRIPTION
## Summary
- ensure generated frpc config paths are writable files even if docker created directories
- invoke the helper while writing configs so generation succeeds during container startup

## Testing
- node - <<'NODE'
const { ensureConfigFiles } = require('./src/frpcManager');
ensureConfigFiles({});
console.log('ok');
NODE

------
https://chatgpt.com/codex/tasks/task_e_68c95facb2dc832d9f18a6544dfbe8b3